### PR TITLE
修改 moveBlock API 接口参数的类型声明

### DIFF
--- a/src/api/server-api.ts
+++ b/src/api/server-api.ts
@@ -422,7 +422,7 @@ export async function deleteBlock(id) {
     return parseBody(request(url, { id }));
 }
 
-export async function moveBlock(id: string, previousID: string, parentID: string) {
+export async function moveBlock(id: string, previousID: string | null = null, parentID: string | null = null) {
     let url = '/api/block/moveBlock';
     return parseBody(
         request(url, { id: id, previousID: previousID, parentID: parentID })


### PR DESCRIPTION
用到了 moveBlock  API 的时候发现，`previousID` 和 `parentID` 都是可以接受 null 参数的，但是原本的 ts 代码的类型标注只标了 string。不影响运行但是编辑器会有红线报 error。于是修改一下 api 接口参数类型。