### PR TITLE
Update TAVCol type with current values

### DIFF
--- a/siyuan.d.ts
+++ b/siyuan.d.ts
@@ -60,6 +60,12 @@ export type TAVCol =
     | "url"
     | "email"
     | "phone"
+    | "mAsset"
+    | "template"
+    | "created"
+    | "updated"
+    | "checkbox"
+    | "lineNumber"
 
 export interface ISiyuan {
     config: Config.IConf;


### PR DESCRIPTION
Hi 👋 

While working on https://github.com/macavity/siyuan-database-properties-panel I realized that the `TAVCol` type does not seem to have all values. So I've create a PR to update it, I hope this is acceptable 😄 