### PR TITLE
Update Constants

### DIFF
--- a/types/constants.ts
+++ b/types/constants.ts
@@ -435,6 +435,7 @@ export abstract class Constants {
                 exitFocus: {default: "", custom: ""},
                 ai: {default: "", custom: ""},
                 switchReadonly: {default: "", custom: ""},
+                switchAdjust: {default: "", custom: ""},
             },
             insert: {
                 appearance: {default: "⌥⌘X", custom: "⌥⌘X"},
@@ -650,7 +651,8 @@ export abstract class Constants {
         "docTitle": true,
         "codeBlock": false,
         "mathBlock": false,
-        "htmlBlock": false
+        "htmlBlock": false,
+        "fileAnnotationRef": false
     };
 
     // image


### PR DESCRIPTION
The recent version 1.1.2 caused two type errors:
```
/siyuan@1.1.2/node_modules/siyuan/types/constants.ts:383:13
Error: Property 'switchAdjust' is missing in type '{ duplicate: { default: string; custom: string; }; expandDown: { default: string; custom: string; }; expandUp: { default: string; custom: string; }; expand: { default: string; custom: string; }; collapse: { ...; }; ... 48 more ...; switchReadonly: { ...; }; }' but required in type 'IKeymapEditorGeneral'.

/siyuan@1.1.2/node_modules/siyuan/types/constants.ts:629:28
Error: Property 'fileAnnotationRef' is missing in type '{ text: true; imgText: true; imgTitle: true; imgSrc: false; aText: true; aTitle: true; aHref: false; code: false; em: true; strong: true; inlineMath: false; inlineMemo: true; blockRef: false; kbd: true; mark: true; ... 8 more ...; htmlBlock: false; }' but required in type 'Required<IUILayoutTabSearchConfigReplaceTypes>'.
```

