### PR TITLE
adjust imports to separate type-only and regular imports

### DIFF
--- a/siyuan.d.ts
+++ b/siyuan.d.ts
@@ -1,26 +1,31 @@
-import {
+import type {
     IGetDocInfo,
     IGetTreeStat,
     IMenuBaseDetail,
-    Config,
-    Custom,
-    Dock,
     IMenu,
     IObject,
     IPosition,
     ISiyuan,
     IWebSocketData,
     IProtyle,
+    IProtyleOptions,
+    TProtyleAction,
+    IMenuItem,
+    IRefDefs,
+} from "./types";
+import {
+    Config,
+    Custom,
+    Dock,
     Lute,
     Protyle,
     Toolbar,
-    IProtyleOptions,
-    TProtyleAction,
     subMenu,
     App,
     Files,
-    Tab, Model,
-    IMenuItem, IRefDefs, MobileCustom,
+    Tab,
+    Model,
+    MobileCustom,
 } from "./types";
 
 export * from "./types";

--- a/types/constants.ts
+++ b/types/constants.ts
@@ -1,4 +1,4 @@
-import {IObject, Config} from "../siyuan";
+import type {IObject, Config} from "../siyuan";
 
 const altNumber = navigator.platform.toUpperCase().indexOf("MAC") > -1 ? "⌃" : "⌥";
 


### PR DESCRIPTION
Projects using TS 5 with "verbatimModuleSyntax": true error on value-style imports of types from the siyuan package. This PR converts type-only imports/exports in types/ to import type / export type. No runtime changes. Verified by linking into a plugin project that previously reproduced the error.