### PR TITLE
Add client-side kernel plugin types and update event bus interface

### DIFF
--- a/kernel.d.ts
+++ b/kernel.d.ts
@@ -446,10 +446,8 @@ export interface IPlugin {
  * advancing to the next lifecycle stage. Unset callbacks (`null`) are skipped.
  */
 export interface IPluginLifecycle {
-    /** Called when the plugin script is first evaluated (before the runtime is fully ready). */
+    /** Called when the plugin script is first evaluated (before the `running` state.). */
     onload: (() => void | Promise<void>) | null;
-    /** Called after the plugin has fully loaded and its runtime is initialized. */
-    onloaded: (() => void | Promise<void>) | null;
     /** Called when the plugin transitions to the `running` state. */
     onrunning: (() => void | Promise<void>) | null;
     /** Called when the plugin is being unloaded (e.g. on shutdown or hot-reload). */

--- a/siyuan.d.ts
+++ b/siyuan.d.ts
@@ -13,6 +13,7 @@ import type {
     IMenuItem,
     IRefDefs,
     TEditorMode,
+    IKernelPlugin,
 } from "./types";
 import {
     Config,
@@ -27,7 +28,6 @@ import {
     Model,
     MobileCustom,
 } from "./types";
-
 export * from "./types";
 
 declare global {
@@ -443,6 +443,7 @@ export function hideMessage(id?: string): void;
 export abstract class Plugin {
     eventBus: EventBus;
     i18n: IObject;
+    kernel: IKernelPlugin;
     data: any;
     displayName: string;
     readonly name: string;

--- a/siyuan.d.ts
+++ b/siyuan.d.ts
@@ -14,6 +14,7 @@ import type {
     IRefDefs,
     TEditorMode,
     IKernelPlugin,
+    IKernelPluginState,
 } from "./types";
 import {
     Config,
@@ -230,6 +231,7 @@ export interface IEventBusMap {
         languageElements: HTMLElement[],
         protyle: IProtyle
     };
+    "kernel-plugin-state-change": IKernelPluginState;
 }
 
 export interface IPluginDockTab {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ import {MobileBacklinks} from "./mobile/dock/MobileBacklinks";
 
 export * from "./config";
 export * from "./events";
+export * from "./kernel";
 export * from "./protyle";
 export * from "./response";
 export * from "./constants";

--- a/types/kernel.d.ts
+++ b/types/kernel.d.ts
@@ -1,0 +1,126 @@
+/**
+ * 内核插件状态
+ * - `-1`: inactive 内核插件未安装或不可用
+ * - `0`: ready 内核插件已安装但未启动
+ * - `1`: loading 内核插件正在启动
+ * - `2`: loaded 内核插件已启动
+ * - `3`: running 内核插件正在运行, 可正常使用
+ * - `4`: stopping 内核插件正在停止
+ * - `5`: stopped 内核插件已停止
+ * - `6`: error 内核插件出现不可恢复的错误
+ */
+export type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export type TJsonRpcId = string | number;
+export type TJsonRpcMethod = string;
+export type TJsonRpcPositionalParams = any[];
+export type TJsonRpcNamedParams = Record<string, any>;
+export type TJsonRpcParams = TJsonRpcPositionalParams | TJsonRpcNamedParams | undefined;
+export type TJsonRpcMethodParams = TJsonRpcPositionalParams | [TJsonRpcNamedParams] | [];
+export type TJsonRpcHandler<T = any> = (...args: TJsonRpcMethodParams) => Promise<T> | T;
+
+
+export interface IKernelPlugin {
+    /**
+     * 内核插件的状态管理接口
+     */
+    state: IKernelPluginState;
+
+    /**
+     * 内核插件的 JSON-RPC 调用接口
+     */
+    rpc: IKernelPluginRpc;
+}
+
+export interface IKernelPluginState {
+    /**
+     * 内核插件的当前状态
+     */
+    code: TKernelPluginState;
+
+    /**
+     * 内核插件状态的描述信息
+     */
+    description: string;
+
+    /**
+     * 当内核插件的状态发生变化时触发的事件处理函数，插件开发者可以通过 `onchange` 来监听状态变化
+     */
+    onchange: ((state: TKernelPluginState) => void) | null;
+}
+
+export interface IKernelPluginRpcCall {
+    /**
+     * JSON-RPC 2.0 中 method 必须是 string，且插件开发者需要保证传入的方法名与内核插件绑定的方法名一致，否则可能会导致调用失败
+     */
+    method: TJsonRpcMethod;
+
+    /**
+     * JSON-RPC 2.0 中 id 可以是 string、number 或 null，但为了兼容性和实用性，插件系统中不允许使用 null 作为 id
+     * 
+     * 不设置时且 notification 不为 true 时会自动生成一个唯一的 id，设置时必须保证 id 的唯一性，否则可能会导致响应错误或混乱
+     */
+    id?: TJsonRpcId;
+
+    /**
+     * JSON-RPC 2.0 中 params 可以是 array 或 object，插件开发者需要自行保证传入参数与内核插件绑定的方法参数一致
+     */
+    params?: any[] | Record<string, any>;
+
+    /**
+     * 是否为通知，通知不会有响应，且不应传入 id
+     * @defaultValue false
+     */
+    notification?: boolean;
+}
+
+export interface IKernelPluginRpcRequest extends IKernelPluginRpcCall {
+    jsonrpc: "2.0";
+}
+
+export interface IKernelPluginRpcBaseResponse {
+    jsonrpc: "2.0";
+}
+
+export interface IKernelPluginRpcResultResponse extends IKernelPluginRpcBaseResponse {
+    id: TJsonRpcId;
+    result?: any;
+}
+
+export interface IKernelPluginRpcErrorResponse extends IKernelPluginRpcBaseResponse {
+    id: TJsonRpcId | null;
+    error?: any;
+}
+
+export interface IKernelPluginRpcError {
+    code: number;
+    message: string;
+    data?: any;
+}
+
+export interface IKernelPluginRpc {
+    /**
+     * 通过 {@link Proxy} 实现的动态方法调用，插件开发者可以直接调用 `call.方法名(params)` 来调用内核插件暴露的方法，无需关心 JSON-RPC 的细节
+     */
+    call: Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => Promise<any>>;
+
+    /**
+     * 通过 {@link Proxy} 实现的动态方法调用，插件开发者可以直接调用 `notify.方法名(...args)` 来发送通知给内核插件，无需关心 JSON-RPC 的细节
+     */
+    notify: Record<TJsonRpcMethod, (...args: TJsonRpcMethodParams) => void>;
+
+    /**
+     * 批量调用方法，接受一个方法调用数组，返回一个结果数组，结果数组中的每一项对应方法调用数组中非通知的每一项，包含成功的结果或错误信息
+     */
+    batch: (...calls: IKernelPluginRpcCall[]) => Promise<IKernelPluginRpcError | (IKernelPluginRpcResultResponse | IKernelPluginRpcErrorResponse)[]>;
+
+    /**
+     * 绑定内核插件调用时的事件处理函数，插件开发者可以通过 `bind("方法名", handler)` 来监听内核插件通过 JSON-RPC 推送到客户端插件的通知
+     */
+    bind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => void;
+
+    /**
+     * 解绑事件处理函数，插件开发者可以通过 `unbind("方法名", handler)` 来停止监听内核插件通过 JSON-RPC 推送到客户端插件的通知
+     */
+    unbind: (method: TJsonRpcMethod, handler: TJsonRpcHandler<void>) => void;
+}

--- a/types/kernel.d.ts
+++ b/types/kernel.d.ts
@@ -3,11 +3,10 @@
  * - `-1`: inactive 内核插件未安装或不可用
  * - `0`: ready 内核插件已安装但未启动
  * - `1`: loading 内核插件正在启动
- * - `2`: loaded 内核插件已启动
- * - `3`: running 内核插件正在运行, 可正常使用
- * - `4`: stopping 内核插件正在停止
- * - `5`: stopped 内核插件已停止
- * - `6`: error 内核插件出现不可恢复的错误
+ * - `2`: running 内核插件正在运行, 可正常使用
+ * - `3`: stopping 内核插件正在停止
+ * - `4`: stopped 内核插件已停止
+ * - `5`: error 内核插件出现不可恢复的错误
  */
 export type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5
 

--- a/types/kernel.d.ts
+++ b/types/kernel.d.ts
@@ -9,7 +9,7 @@
  * - `5`: stopped 内核插件已停止
  * - `6`: error 内核插件出现不可恢复的错误
  */
-export type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6
+export type TKernelPluginState = -1 | 0 | 1 | 2 | 3 | 4 | 5
 
 export type TJsonRpcId = string | number;
 export type TJsonRpcMethod = string;

--- a/types/kernel.d.ts
+++ b/types/kernel.d.ts
@@ -42,11 +42,6 @@ export interface IKernelPluginState {
      * 内核插件状态的描述信息
      */
     description: string;
-
-    /**
-     * 当内核插件的状态发生变化时触发的事件处理函数，插件开发者可以通过 `onchange` 来监听状态变化
-     */
-    onchange: ((state: TKernelPluginState) => void) | null;
 }
 
 export interface IKernelPluginRpcCall {


### PR DESCRIPTION
新增客户端插件中与内核插件相关的接口
Added interfaces related to kernel plugin in client plugin

- `this.kernel.state.code` 当前内核插件状态码
- `this.kenrel.state.description` 当前内核插件状态描述
- `this.kernel.rpc.call` 通过 JSON RPC 调用内核插件注册的方法
- `this.kernel.rpc.notify` 通过 JSON RPC 向内核插件指定方法推送通知
- `this.kernel.rpc.batch` 通过 JSON RPC 批量调用内核插件注册的方法
- `this.kernel.rpc.bind` 绑定一个可供内核插件通过 JSON RPC 推送通知的方法
- `this.kernel.rpc.unbind` 解绑一个可供内核插件通过 JSON RPC 推送通知的方法
- `this.eventBus.on("kernel-plugin-state-change", handler)` 监听内核插件状态变更事件